### PR TITLE
Jz create page menuitemreview

### DIFF
--- a/frontend/src/main/pages/MenuItemReviews/MenuItemReviewsCreatePage.js
+++ b/frontend/src/main/pages/MenuItemReviews/MenuItemReviewsCreatePage.js
@@ -1,11 +1,50 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import MenuItemReviewForm from "main/components/MenuItemReviews/MenuItemReviewForm";
+import { Navigate } from "react-router-dom";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function MenuItemReviewsCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function MenuItemReviewsCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (menuitemreview) => ({
+    url: "/api/menuitemreview/post",
+    method: "POST",
+    params: {
+      itemId: menuitemreview.itemId,
+      reviewerEmail: menuitemreview.reviewerEmail,
+      stars: menuitemreview.stars,
+      dateReviewed: menuitemreview.dateReviewed,
+      comments: menuitemreview.comments,
+    },
+  });
+
+  const onSuccess = (menuitemreview) => {
+    toast(
+      `New menu item review Created - id: ${menuitemreview.id} itemId: ${menuitemreview.itemId}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/menuitemreview/all"], // mutation makes this key stale so that pages relying on it reload
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/menuitemreviews" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New Menu Item Review</h1>
+        <MenuItemReviewForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewsCreatePage.stories.js
+++ b/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewsCreatePage.stories.js
@@ -1,0 +1,32 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import MenuItemReviewsCreatePage from "main/pages/MenuItemReviews/MenuItemReviewsCreatePage";
+
+export default {
+  title: "pages/MenuItemReviews/MenuItemReviewsCreatePage",
+  component: MenuItemReviewsCreatePage,
+};
+
+const Template = () => <MenuItemReviewsCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/menuitemreview/post", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewsCreatePage.test.js
+++ b/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewsCreatePage.test.js
@@ -1,17 +1,42 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import MenuItemReviewsCreatePage from "main/pages/MenuItemReviews/MenuItemReviewsCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
+});
 
 describe("MenuItemReviewsCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -20,15 +45,10 @@ describe("MenuItemReviewsCreatePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-
-    setupUserOnly();
-
-    // act
+  test("renders without crashing", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -37,8 +57,86 @@ describe("MenuItemReviewsCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
+    await waitFor(() => {
+      expect(screen.getByLabelText("Item Id")).toBeInTheDocument();
+    });
+  });
 
-    await screen.findByText("Create page not yet implemented");
+  test("on submit, makes request to backend, and redirects to /menuitemreviews", async () => {
+    const queryClient = new QueryClient();
+    const menuitemreview = {
+      id: 1,
+      itemId: 1,
+      reviewerEmail: "jasonzhao@ucsb.edu",
+      stars: 5,
+      dateReviewed: "2025-05-03T06:19:23",
+      comments: "good",
+    };
+
+    axiosMock.onPost("/api/menuitemreview/post").reply(202, menuitemreview);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewsCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Item Id")).toBeInTheDocument();
+    });
+
+    const itemIdInput = screen.getByLabelText("Item Id");
+    expect(itemIdInput).toBeInTheDocument();
+
+    const reviewerEmailInput = screen.getByLabelText("Reviewer Email");
+    expect(reviewerEmailInput).toBeInTheDocument();
+
+    const starsInput = screen.getByLabelText("Stars");
+    expect(starsInput).toBeInTheDocument();
+
+    const dateReviewedInput = screen.getByLabelText(
+      "Date Reviewed(iso format)",
+    );
+    expect(dateReviewedInput).toBeInTheDocument();
+
+    const commentsInput = screen.getByLabelText("Comments");
+    expect(commentsInput).toBeInTheDocument();
+
+    const createButton = screen.getByText("Create");
+    expect(createButton).toBeInTheDocument();
+
+    fireEvent.change(itemIdInput, { target: { value: "1" } });
+
+    fireEvent.change(reviewerEmailInput, {
+      target: { value: "jasonzhao@ucsb.edu" },
+    });
+
+    fireEvent.change(starsInput, { target: { value: "5" } });
+
+    fireEvent.change(dateReviewedInput, {
+      target: { value: "2025-05-03T06:19:23" },
+    });
+
+    fireEvent.change(commentsInput, { target: { value: "good" } });
+
+    fireEvent.click(createButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      itemId: "1",
+      reviewerEmail: "jasonzhao@ucsb.edu",
+      stars: "5",
+      dateReviewed: "2025-05-03T06:19:23.000",
+      comments: "good",
+    });
+
+    // assert - check that the toast was called with the expected message
+    expect(mockToast).toHaveBeenCalledWith(
+      "New menu item review Created - id: 1 itemId: 1",
+    );
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/menuitemreviews" });
   });
 });


### PR DESCRIPTION
Closes #40 

PR: replaced the placeholder create page with a working create page for menu item reviews

Note: I previously opened another PR with a different branch, but it had like 6 merge conflicts and it was hard to do so I just redid the create page using a new branch off of main. 

Note 2: The yellow circle is due to the billing issue. 

Storybook: https://68116a8f444f1925b7e69935-wocjimdewr.chromatic.com/?path=/story/pages-menuitemreviews-menuitemreviewscreatepage--default

# To Test: 
use this dokku: https://team02-dev-jasozh5.dokku-09.cs.ucsb.edu/
Navigate to create page for menu item review
fill in the fields
click create
check the /api/menuitemreview/all endpoint with swagger